### PR TITLE
Update Multicaixa Express demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # Penelope
-Melitapenelope
+
+Exemplo simples de integração com o Multicaixa Express utilizando a API da AppyPay.
+
+Este repositório inclui o arquivo `multicaixa_express_demo.py`, que demonstra como criar um pedido de pagamento e redirecionar o usuário diretamente para concluir a transação no aplicativo Multicaixa Express.
+
+## Requisitos
+- Python 3.8 ou superior
+- Bibliotecas `requests` e `Flask`
+- Chave de API da AppyPay (definida na variável de ambiente `APPY_API_KEY`)
+
+## Executando o exemplo
+
+1. Instale as dependências:
+
+```bash
+pip install Flask requests
+```
+
+2. Defina sua chave da API:
+
+```bash
+export APPY_API_KEY=SEU_TOKEN_DA_APPYPAY
+```
+
+3. Execute o servidor de exemplo:
+
+```bash
+python multicaixa_express_demo.py
+```
+
+4. Acesse `http://localhost:5000` em seu navegador, informe o valor e clique em **Processar**. Você será redirecionado diretamente para o aplicativo Multicaixa Express para concluir o pagamento.

--- a/multicaixa_express_demo.py
+++ b/multicaixa_express_demo.py
@@ -1,0 +1,73 @@
+import os
+import requests
+from flask import Flask, request, redirect, render_template_string
+
+# Configuração: defina sua chave da API da AppyPay no ambiente
+APPY_API_KEY = os.environ.get("APPY_API_KEY")
+
+if not APPY_API_KEY:
+    raise EnvironmentError("Defina a variável de ambiente APPY_API_KEY com a sua chave da API AppyPay")
+
+APPYPAY_ENDPOINT = "https://api.appypay.co.ao/v1/payments"
+
+app = Flask(__name__)
+
+FORM_HTML = """
+<!doctype html>
+<title>Pagamento Multicaixa Express</title>
+<h1>Processar Pagamento</h1>
+<form action="/processar" method="post">
+  <label for="valor">Valor (AOA):</label>
+  <input type="number" id="valor" name="valor" min="1" required>
+  <button type="submit">Processar</button>
+</form>
+"""
+
+
+def criar_pedido_pagamento(valor, descricao="Pagamento via Multicaixa Express"):
+    """Cria um pedido de pagamento na API AppyPay e retorna o link para o app
+    Multicaixa Express."""
+
+    payload = {
+        "amount": int(valor),
+        "currency": "AOA",
+        "description": descricao,
+    }
+    headers = {
+        "Authorization": f"Bearer {APPY_API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+    resp = requests.post(APPYPAY_ENDPOINT, json=payload, headers=headers)
+    resp.raise_for_status()
+
+    data = resp.json()
+
+    # A API da AppyPay pode retornar um deep link específico para o app
+    # Multicaixa Express. Caso não esteja presente, utiliza o link de checkout
+    # padrão da AppyPay como fallback.
+    return data.get("mceDeeplink") or data.get("checkoutUrl")
+
+
+@app.route("/")
+def index():
+    return render_template_string(FORM_HTML)
+
+
+@app.route("/processar", methods=["POST"])
+def processar_pagamento():
+    valor = request.form.get("valor")
+    if not valor:
+        return "Valor inválido", 400
+
+    try:
+        checkout_url = criar_pedido_pagamento(valor)
+    except requests.HTTPError as exc:
+        return f"Erro ao criar pedido de pagamento: {exc}", 500
+
+    # Redireciona o cliente diretamente para o aplicativo Multicaixa Express
+    return redirect(checkout_url)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- adjust docs to describe direct Multicaixa Express redirect
- return deep link to Multicaixa Express if provided

## Testing
- `python -m py_compile multicaixa_express_demo.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68544f585c408332a43da71666e2a796