### PR TITLE
Implement basic Laravel layout and home page

### DIFF
--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
+
+class SiteController extends Controller
+{
+    public function home()
+    {
+        return view('home');
+    }
+
+    public function submitContact(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email',
+            'message' => 'required|string',
+        ]);
+
+        // Mail::to(config('mail.from.address'))->send(new ContactMail($data));
+        return back()->with('success', 'Mensagem enviada com sucesso!');
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const menuToggle = document.getElementById('menuToggle');
+    const mobileMenu = document.getElementById('mobileMenu');
+    const themeToggle = document.getElementById('themeToggle');
+    const html = document.documentElement;
+
+    if (menuToggle) {
+        menuToggle.addEventListener('click', () => {
+            mobileMenu.classList.toggle('hidden');
+        });
+    }
+
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+            html.classList.toggle('dark');
+        });
+    }
+
+    if (window.AOS) {
+        AOS.init();
+    }
+});

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.app')
+
+@section('content')
+<section class="relative flex items-center justify-center h-screen bg-cover bg-center" style="background-image: url('/images/hero.jpg')" data-aos="fade-in">
+    <div class="text-center bg-white/70 dark:bg-gray-800/70 p-6 rounded">
+        <h1 class="text-4xl md:text-6xl font-bold mb-4">Bem-vindo à nossa Igreja</h1>
+        <p class="text-lg md:text-2xl">"Ide por todo o mundo e pregai o evangelho"</p>
+    </div>
+</section>
+
+<section id="sermoes" class="py-12" data-aos="fade-up">
+    <div class="container mx-auto px-4">
+        <h2 class="text-2xl font-semibold mb-6">Últimos Sermões</h2>
+        <div class="grid md:grid-cols-3 gap-4">
+            <iframe class="w-full h-60" src="https://www.youtube.com/embed/videoid" title="Sermão" allowfullscreen></iframe>
+            <iframe class="w-full h-60" src="https://www.youtube.com/embed/videoid" title="Sermão" allowfullscreen></iframe>
+            <iframe class="w-full h-60" src="https://www.youtube.com/embed/videoid" title="Sermão" allowfullscreen></iframe>
+        </div>
+    </div>
+</section>
+
+<section id="eventos" class="py-12 bg-gray-100 dark:bg-gray-800" data-aos="fade-up">
+    <div class="container mx-auto px-4">
+        <h2 class="text-2xl font-semibold mb-6">Próximos Eventos</h2>
+        <div id="calendar"></div>
+    </div>
+</section>
+
+<section id="contato" class="py-12" data-aos="fade-up">
+    <div class="container mx-auto px-4">
+        <h2 class="text-2xl font-semibold mb-6">Fale Conosco</h2>
+        <form method="POST" action="{{ route('contact.submit') }}" class="space-y-4">
+            @csrf
+            <div>
+                <label class="block">Nome</label>
+                <input type="text" name="name" class="w-full p-2 border rounded" required>
+            </div>
+            <div>
+                <label class="block">Email</label>
+                <input type="email" name="email" class="w-full p-2 border rounded" required>
+            </div>
+            <div>
+                <label class="block">Mensagem</label>
+                <textarea name="message" class="w-full p-2 border rounded" required></textarea>
+            </div>
+            <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Enviar</button>
+        </form>
+    </div>
+</section>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="scroll-smooth">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name', 'Igreja Adventista') }}</title>
+    <meta name="description" content="Igreja Adventista do Sétimo Dia - Site institucional" />
+    @vite('resources/css/app.css')
+    @stack('head')
+</head>
+<body class="antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    @include('partials.header')
+    <main>
+        @yield('content')
+    </main>
+    @vite('resources/js/app.js')
+    @stack('scripts')
+</body>
+</html>

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -1,0 +1,32 @@
+<header class="sticky top-0 z-50 bg-white/70 backdrop-blur dark:bg-gray-800/70">
+    <div class="container mx-auto flex justify-between items-center p-4">
+        <a href="/" class="text-xl font-bold">{{ config('app.name', 'Igreja Adventista') }}</a>
+        <nav class="hidden md:flex space-x-4">
+            <a href="#sobre" class="hover:text-blue-600">Sobre</a>
+            <a href="#ministerios" class="hover:text-blue-600">Ministérios</a>
+            <a href="#noticias" class="hover:text-blue-600">Notícias</a>
+            <a href="#eventos" class="hover:text-blue-600">Eventos</a>
+            <a href="#programacao" class="hover:text-blue-600">Programação</a>
+            <a href="#doacoes" class="hover:text-blue-600">Doações</a>
+            <a href="#contato" class="hover:text-blue-600">Contato</a>
+        </nav>
+        <div class="flex items-center space-x-4">
+            <button id="themeToggle" class="p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700">
+                <svg id="themeIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8.66-9h-1M4.34 12h-1m14.14 7.07l-.7-.7M6.22 6.22l-.7-.7m12.02 12.95l-.7.7M6.22 17.78l-.7.7M12 5a7 7 0 100 14a7 7 0 000-14z"></path></svg>
+            </button>
+            <a href="#doar" class="bg-blue-600 text-white px-3 py-2 rounded-md hover:bg-blue-700">Doar</a>
+            <button id="menuToggle" class="md:hidden p-2">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
+            </button>
+        </div>
+    </div>
+    <div id="mobileMenu" class="md:hidden hidden flex-col space-y-2 px-4 pb-4">
+        <a href="#sobre" class="block">Sobre</a>
+        <a href="#ministerios" class="block">Ministérios</a>
+        <a href="#noticias" class="block">Notícias</a>
+        <a href="#eventos" class="block">Eventos</a>
+        <a href="#programacao" class="block">Programação</a>
+        <a href="#doacoes" class="block">Doações</a>
+        <a href="#contato" class="block">Contato</a>
+    </div>
+</header>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\SiteController;
+
+Route::get('/', [SiteController::class, 'home'])->name('home');
+Route::post('/contato', [SiteController::class, 'submitContact'])->name('contact.submit');


### PR DESCRIPTION
## Summary
- scaffold Laravel-style structure
- add Blade layout and header
- create home page with sermon and event sections
- add simple SiteController and routes
- add JS for mobile menu and theme toggle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870cf3764b483328da7f399c26b8eed