### PR TITLE
Add base schema and PHP login prototype

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DB_DSN=pgsql:host=localhost;dbname=edumanager
+DB_USER=postgres
+DB_PASS=secret

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Penelope
-Melitapenelope
+# EduManager Skeleton
+
+This repository contains a basic database schema and a simple PHP prototype for the EduManager school management system. It now includes early academic, financial and homework features and is intended as a starting point for further development.
+
+## Structure
+- `db/init_schema.sql` – core tables and RPC functions (`verificar_perfil`, `atualizar_senha`, `registrar_login`, `gerar_boletim`, `emitir_recibo`, `notificar`, `get_agenda_professor`, `gerar_fatura_agt`, `listar_tarefas_por_turma`, `responder_tarefa`, `avaliar_resposta_tarefa`).
+- `db/seed.sql` – initial data for levels, courses, a sample class, evaluation, payment, notifications, a demo task and an example message.
+- `frontend/` – PHP pages for login, dashboard, profile (password update), student report card, task submission and simple messaging.
+- `.env.example` – example environment variables for database connection.
+
+## Usage
+1. Create a PostgreSQL database and run `db/init_schema.sql` then `db/seed.sql`.
+2. Copy `.env.example` to `.env` and adjust credentials.
+3. Place the `frontend/` folder in your PHP server root and access `index.php`.
+
+This remains a minimal foundation; advanced modules (complete finance, agenda, notifications, etc.) should be implemented on top of this structure.

--- a/db/init_schema.sql
+++ b/db/init_schema.sql
@@ -1,0 +1,458 @@
+-- EduManager init_schema.sql
+-- This script creates core tables for authentication, multi-school, and profiles.
+
+-- Enable extensions as needed (PostgreSQL)
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- 1. Owners table for SaaS multi-institution
+CREATE TABLE proprietarios (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    nome TEXT NOT NULL,
+    email TEXT UNIQUE NOT NULL,
+    telefone TEXT,
+    senha TEXT NOT NULL,
+    criado_em TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    ultimo_login TIMESTAMP WITH TIME ZONE
+);
+
+-- 2. Schools table
+CREATE TABLE escolas (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    proprietario_id UUID REFERENCES proprietarios(id) ON DELETE SET NULL,
+    nome_oficial TEXT NOT NULL,
+    categoria TEXT,
+    nif TEXT,
+    email TEXT,
+    telefone TEXT,
+    endereco TEXT,
+    provincia TEXT,
+    municipio TEXT,
+    comuna TEXT,
+    logotipo_url TEXT,
+    status TEXT DEFAULT 'ativa',
+    criado_em TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+-- 3. Plans and subscriptions
+CREATE TABLE planos (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    nome TEXT NOT NULL,
+    preco_mensal NUMERIC(10,2) DEFAULT 0,
+    funcionalidades JSONB DEFAULT '[]'::jsonb,
+    limite_usuarios INTEGER,
+    limite_gb_armazenamento INTEGER,
+    duracao_meses INTEGER,
+    status TEXT DEFAULT 'ativo'
+);
+
+CREATE TABLE assinaturas (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    escola_id UUID REFERENCES escolas(id) ON DELETE CASCADE,
+    plano_id UUID REFERENCES planos(id) ON DELETE SET NULL,
+    status TEXT DEFAULT 'ativa',
+    data_inicio DATE,
+    data_fim DATE,
+    metodo_pagamento TEXT,
+    ultima_renovacao DATE,
+    gateway_transacao_id TEXT
+);
+
+CREATE TABLE modulos_escola (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    escola_id UUID REFERENCES escolas(id) ON DELETE CASCADE,
+    nome_modulo TEXT NOT NULL,
+    liberado BOOLEAN DEFAULT false,
+    liberado_por_assinatura BOOLEAN DEFAULT true
+);
+
+-- 4. Users
+CREATE TABLE usuarios (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    escola_id UUID REFERENCES escolas(id) ON DELETE CASCADE,
+    nome TEXT NOT NULL,
+    bi TEXT UNIQUE NOT NULL,
+    senha TEXT NOT NULL,
+    tipo TEXT NOT NULL,
+    email TEXT,
+    telefone TEXT,
+    ativo BOOLEAN DEFAULT true,
+    ultimo_login TIMESTAMP WITH TIME ZONE,
+    criado_em TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    atualizado_em TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+-- 5. Students
+CREATE TABLE alunos (
+    usuario_id UUID PRIMARY KEY REFERENCES usuarios(id) ON DELETE CASCADE,
+    turma_id UUID,
+    data_nascimento DATE,
+    genero TEXT,
+    nacionalidade TEXT,
+    nome_pai TEXT,
+    telefone_pai TEXT,
+    nome_mae TEXT,
+    telefone_mae TEXT,
+    nome_encarregado TEXT,
+    telefone_encarregado TEXT,
+    grau_parentesco TEXT,
+    provincia TEXT,
+    municipio TEXT,
+    comuna TEXT,
+    endereco TEXT
+);
+
+-- 6. Teachers
+CREATE TABLE professores (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    usuario_id UUID UNIQUE REFERENCES usuarios(id) ON DELETE CASCADE,
+    especialidade TEXT,
+    grau_academico TEXT,
+    bi_professor TEXT UNIQUE,
+    numero_agente TEXT,
+    data_admissao DATE,
+    situacao_profissional TEXT,
+    provincia TEXT,
+    municipio TEXT,
+    comuna TEXT,
+    endereco TEXT,
+    carga_horaria_total INTEGER,
+    turno TEXT,
+    regime TEXT,
+    salario_base NUMERIC(12,2),
+    vinculo_escolar TEXT,
+    cv_url TEXT,
+    certificados_url TEXT,
+    observacoes TEXT,
+    criado_em TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    atualizado_em TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+-- 7. Login logs
+CREATE TABLE logs_usuarios (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    usuario_id UUID REFERENCES usuarios(id) ON DELETE CASCADE,
+    ip_address TEXT,
+    navegador TEXT,
+    sistema_operacional TEXT,
+    dispositivo TEXT,
+    user_agent TEXT,
+    data_login TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    tipo_login TEXT,
+    sucesso BOOLEAN,
+    tentativa_falha BOOLEAN DEFAULT false,
+    localizacao_aproximada TEXT,
+    navegador_id TEXT,
+    nota_de_alerta TEXT,
+    evento TEXT
+);
+
+-- 8. Academic core tables
+CREATE TABLE niveis_ensino (
+    id SERIAL PRIMARY KEY,
+    nome TEXT NOT NULL
+);
+
+CREATE TABLE cursos (
+    id SERIAL PRIMARY KEY,
+    nivel_id INTEGER REFERENCES niveis_ensino(id) ON DELETE CASCADE,
+    nome TEXT NOT NULL,
+    duracao_anos INTEGER,
+    descricao TEXT,
+    ativo BOOLEAN DEFAULT true
+);
+
+CREATE TABLE disciplinas (
+    id SERIAL PRIMARY KEY,
+    curso_id INTEGER REFERENCES cursos(id) ON DELETE CASCADE,
+    professor_id UUID REFERENCES professores(id) ON DELETE SET NULL,
+    nome TEXT NOT NULL,
+    carga_horaria INTEGER,
+    periodo INTEGER,
+    tipo TEXT
+);
+
+CREATE TABLE turmas (
+    id SERIAL PRIMARY KEY,
+    curso_id INTEGER REFERENCES cursos(id) ON DELETE CASCADE,
+    nome TEXT NOT NULL,
+    ano_letivo TEXT,
+    turno TEXT,
+    sala TEXT,
+    periodo_letivo INTEGER
+);
+
+-- Academic progress and finance tables
+CREATE TABLE avaliacoes (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    turma_id INTEGER REFERENCES turmas(id) ON DELETE CASCADE,
+    disciplina_id INTEGER REFERENCES disciplinas(id) ON DELETE CASCADE,
+    professor_id UUID REFERENCES professores(id) ON DELETE SET NULL,
+    tipo TEXT,
+    peso NUMERIC,
+    data_aplicacao DATE,
+    descricao TEXT
+);
+
+CREATE TABLE notas (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    avaliacao_id UUID REFERENCES avaliacoes(id) ON DELETE CASCADE,
+    aluno_id UUID REFERENCES alunos(usuario_id) ON DELETE CASCADE,
+    nota NUMERIC,
+    observacao TEXT,
+    registrada_em TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+CREATE TABLE pagamentos (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    aluno_id UUID REFERENCES alunos(usuario_id) ON DELETE CASCADE,
+    valor NUMERIC,
+    status TEXT,
+    metodo_pagamento TEXT,
+    vencimento DATE,
+    pago_em DATE,
+    referencia TEXT
+);
+
+CREATE TABLE recibos (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    pagamento_id UUID REFERENCES pagamentos(id) ON DELETE CASCADE,
+    url_pdf TEXT,
+    data_emissao TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    gerado_por UUID REFERENCES usuarios(id) ON DELETE SET NULL
+);
+
+CREATE TABLE agt_faturas (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    pagamento_id UUID REFERENCES pagamentos(id) ON DELETE CASCADE,
+    nif TEXT,
+    valor NUMERIC,
+    xml_fiscal TEXT,
+    status TEXT,
+    hash_assinatura TEXT,
+    motivo_erro TEXT,
+    criado_em TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+CREATE TABLE agenda_eventos (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    professor_id UUID REFERENCES professores(id) ON DELETE CASCADE,
+    turma_id INTEGER REFERENCES turmas(id) ON DELETE CASCADE,
+    titulo TEXT,
+    tipo TEXT,
+    data_inicio TIMESTAMP WITH TIME ZONE,
+    data_fim TIMESTAMP WITH TIME ZONE,
+    descricao TEXT
+);
+
+CREATE TABLE notificacoes (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    usuario_id UUID REFERENCES usuarios(id) ON DELETE CASCADE,
+    titulo TEXT,
+    conteudo TEXT,
+    tipo TEXT,
+    lida BOOLEAN DEFAULT false,
+    criada_em TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+-- Messaging between users
+CREATE TABLE mensagens (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    remetente_id UUID REFERENCES usuarios(id) ON DELETE CASCADE,
+    destinatario_id UUID REFERENCES usuarios(id) ON DELETE CASCADE,
+    conteudo TEXT NOT NULL,
+    enviado_em TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    lido_em TIMESTAMP WITH TIME ZONE
+);
+
+-- Additional tables for future modules should follow similar structure.
+
+-- RPC: returns the user type based on BI
+CREATE OR REPLACE FUNCTION verificar_perfil(p_bi TEXT)
+RETURNS TEXT AS $$
+DECLARE v_tipo TEXT;
+BEGIN
+    SELECT tipo INTO v_tipo FROM usuarios WHERE bi = p_bi;
+    RETURN v_tipo;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: update user password if old password matches
+CREATE OR REPLACE FUNCTION atualizar_senha(p_bi TEXT, p_senha_antiga TEXT, p_nova_senha TEXT)
+RETURNS BOOLEAN AS $$
+DECLARE v_hash TEXT;
+BEGIN
+    SELECT senha INTO v_hash FROM usuarios WHERE bi = p_bi;
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+    IF crypt(p_senha_antiga, v_hash) <> v_hash THEN
+        RETURN FALSE;
+    END IF;
+    UPDATE usuarios
+       SET senha = crypt(p_nova_senha, gen_salt('bf')), atualizado_em = now()
+     WHERE bi = p_bi;
+    RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: register login attempt
+CREATE OR REPLACE FUNCTION registrar_login(
+    p_usuario_id UUID,
+    p_sucesso BOOLEAN,
+    p_ip TEXT,
+    p_navegador TEXT,
+    p_so TEXT,
+    p_dispositivo TEXT,
+    p_user_agent TEXT
+)
+RETURNS VOID AS $$
+BEGIN
+    INSERT INTO logs_usuarios(usuario_id, sucesso, ip_address, navegador, sistema_operacional, dispositivo, user_agent)
+    VALUES (p_usuario_id, p_sucesso, p_ip, p_navegador, p_so, p_dispositivo, p_user_agent);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: generate student's grade report
+CREATE OR REPLACE FUNCTION gerar_boletim(p_aluno UUID)
+RETURNS TABLE(disciplina TEXT, nota NUMERIC) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT d.nome, n.nota
+    FROM notas n
+    JOIN avaliacoes a ON n.avaliacao_id = a.id
+    JOIN disciplinas d ON a.disciplina_id = d.id
+    WHERE n.aluno_id = p_aluno;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: create receipt for a payment
+CREATE OR REPLACE FUNCTION emitir_recibo(p_pagamento UUID)
+RETURNS TABLE(id UUID, pagamento_id UUID, url_pdf TEXT, data_emissao TIMESTAMP WITH TIME ZONE, gerado_por UUID) AS $$
+BEGIN
+    RETURN QUERY
+    INSERT INTO recibos(pagamento_id, url_pdf, gerado_por)
+    VALUES (p_pagamento, 'https://example.com/recibo/' || p_pagamento, NULL)
+    RETURNING id, pagamento_id, url_pdf, data_emissao, gerado_por;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: create notification for a user
+CREATE OR REPLACE FUNCTION notificar(p_usuario UUID, p_titulo TEXT, p_conteudo TEXT, p_tipo TEXT)
+RETURNS notificacoes AS $$
+DECLARE v_notif notificacoes%ROWTYPE;
+BEGIN
+    INSERT INTO notificacoes(usuario_id, titulo, conteudo, tipo)
+    VALUES (p_usuario, p_titulo, p_conteudo, p_tipo)
+    RETURNING * INTO v_notif;
+    RETURN v_notif;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: send a message between users
+CREATE OR REPLACE FUNCTION enviar_mensagem(p_remetente UUID, p_destinatario UUID, p_conteudo TEXT)
+RETURNS mensagens AS $$
+DECLARE v_msg mensagens%ROWTYPE;
+BEGIN
+    INSERT INTO mensagens(remetente_id, destinatario_id, conteudo)
+    VALUES (p_remetente, p_destinatario, p_conteudo)
+    RETURNING * INTO v_msg;
+    RETURN v_msg;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: list messages for a user
+CREATE OR REPLACE FUNCTION listar_mensagens(p_usuario UUID)
+RETURNS SETOF mensagens AS $$
+BEGIN
+    RETURN QUERY
+    SELECT * FROM mensagens
+     WHERE remetente_id = p_usuario OR destinatario_id = p_usuario
+     ORDER BY enviado_em DESC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: get agenda events for a professor
+CREATE OR REPLACE FUNCTION get_agenda_professor(p_professor UUID)
+RETURNS SETOF agenda_eventos AS $$
+BEGIN
+    RETURN QUERY SELECT * FROM agenda_eventos WHERE professor_id = p_professor ORDER BY data_inicio;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: generate fiscal invoice and payment
+CREATE OR REPLACE FUNCTION gerar_fatura_agt(p_nif TEXT, p_aluno UUID, p_valor NUMERIC)
+RETURNS agt_faturas AS $$
+DECLARE v_pagamento UUID;
+DECLARE v_fatura agt_faturas%ROWTYPE;
+BEGIN
+    INSERT INTO pagamentos(aluno_id, valor, status)
+    VALUES (p_aluno, p_valor, 'pendente') RETURNING id INTO v_pagamento;
+    INSERT INTO agt_faturas(pagamento_id, nif, valor, xml_fiscal, status, hash_assinatura)
+    VALUES (v_pagamento, p_nif, p_valor, '<xml>simulado</xml>', 'emitida', md5(random()::text))
+    RETURNING * INTO v_fatura;
+    RETURN v_fatura;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Tasks and homework tables
+CREATE TABLE tarefas (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    disciplina_id INTEGER REFERENCES disciplinas(id) ON DELETE CASCADE,
+    turma_id INTEGER REFERENCES turmas(id) ON DELETE CASCADE,
+    professor_id UUID REFERENCES professores(id) ON DELETE SET NULL,
+    titulo TEXT NOT NULL,
+    descricao TEXT,
+    data_entrega DATE,
+    data_publicacao TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    peso NUMERIC,
+    tipo TEXT,
+    arquivo_url TEXT,
+    avaliacao_id UUID REFERENCES avaliacoes(id) ON DELETE SET NULL
+);
+
+CREATE TABLE respostas_tarefas (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    tarefa_id UUID REFERENCES tarefas(id) ON DELETE CASCADE,
+    aluno_id UUID REFERENCES alunos(usuario_id) ON DELETE CASCADE,
+    resposta_url TEXT,
+    nota NUMERIC,
+    comentario_professor TEXT,
+    data_envio TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    avaliada_em TIMESTAMP WITH TIME ZONE
+);
+
+-- RPC: list tasks for a class
+CREATE OR REPLACE FUNCTION listar_tarefas_por_turma(p_turma INTEGER)
+RETURNS SETOF tarefas AS $$
+BEGIN
+    RETURN QUERY SELECT * FROM tarefas WHERE turma_id = p_turma ORDER BY data_entrega;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: student submits task response
+CREATE OR REPLACE FUNCTION responder_tarefa(p_tarefa UUID, p_aluno UUID, p_url TEXT)
+RETURNS respostas_tarefas AS $$
+DECLARE v_resp respostas_tarefas%ROWTYPE;
+BEGIN
+    INSERT INTO respostas_tarefas(tarefa_id, aluno_id, resposta_url)
+    VALUES (p_tarefa, p_aluno, p_url)
+    RETURNING * INTO v_resp;
+    RETURN v_resp;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: teacher grades task response
+CREATE OR REPLACE FUNCTION avaliar_resposta_tarefa(p_tarefa UUID, p_aluno UUID, p_nota NUMERIC, p_comentario TEXT)
+RETURNS respostas_tarefas AS $$
+DECLARE v_resp respostas_tarefas%ROWTYPE;
+BEGIN
+    UPDATE respostas_tarefas
+       SET nota = p_nota,
+           comentario_professor = p_comentario,
+           avaliada_em = now()
+     WHERE tarefa_id = p_tarefa AND aluno_id = p_aluno
+    RETURNING * INTO v_resp;
+    RETURN v_resp;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,0 +1,109 @@
+-- Seed data for EduManager
+INSERT INTO niveis_ensino (nome) VALUES
+('Primário'),
+('Médio'),
+('Técnico'),
+('Técnico de Saúde'),
+('Superior');
+
+-- Courses for Angola
+INSERT INTO cursos (nivel_id, nome, duracao_anos, descricao) VALUES
+(1, 'Educação Geral 1ª a 6ª classe', 6, 'Ensino primário'),
+(2, 'Ciências Físicas e Biológicas', 3, null),
+(2, 'Ciências Económicas e Jurídicas', 3, null),
+(2, 'Ciências Humanas', 3, null),
+(2, 'Ciências Matemáticas', 3, null),
+(2, 'Formação de Professores', 3, null),
+(2, 'Letras', 3, null),
+(2, 'Pedagogia', 3, null),
+(2, 'Informática', 3, null),
+(3, 'Técnico de Informática', 3, null),
+(3, 'Técnico de Contabilidade', 3, null),
+(3, 'Técnico de Administração', 3, null),
+(3, 'Técnico de Construção Civil', 3, null),
+(3, 'Técnico de Mecânica', 3, null),
+(3, 'Técnico de Eletricidade', 3, null),
+(3, 'Técnico de Marketing', 3, null),
+(3, 'Técnico de Estatística', 3, null),
+(3, 'Técnico de Secretariado Executivo', 3, null),
+(4, 'Enfermagem Geral', 3, null),
+(4, 'Laboratório Clínico', 3, null),
+(4, 'Farmácia', 3, null),
+(4, 'Saúde Pública', 3, null),
+(4, 'Radiologia', 3, null),
+(4, 'Nutrição', 3, null),
+(5, 'Engenharia Informática', 5, null),
+(5, 'Engenharia Civil', 5, null),
+(5, 'Engenharia Eletrotécnica', 5, null),
+(5, 'Medicina', 6, null),
+(5, 'Direito', 5, null),
+(5, 'Psicologia', 4, null),
+(5, 'Ciências da Educação', 4, null),
+(5, 'Gestão de Empresas', 4, null),
+(5, 'Economia', 4, null),
+(5, 'Arquitetura', 5, null),
+(5, 'Comunicação Social', 4, null),
+(5, 'Engenharia Mecânica', 5, null),
+(5, 'Engenharia Química', 5, null),
+(5, 'Sociologia', 4, null),
+(5, 'Administração Pública', 4, null);
+
+-- Sample users
+INSERT INTO usuarios (id, nome, bi, senha, tipo, ativo) VALUES
+('11111111-1111-1111-1111-111111111111','Administrador','000000000AB000',crypt('123456', gen_salt('bf')),'admin',true),
+('22222222-2222-2222-2222-222222222222','Professor Demo','000000000AB001',crypt('123456', gen_salt('bf')),'professor',true),
+('33333333-3333-3333-3333-333333333333','Aluno Demo','000000000AB002',crypt('123456', gen_salt('bf')),'aluno',true);
+
+-- Sample teacher profile
+INSERT INTO professores (id, usuario_id, especialidade, grau_academico, bi_professor, numero_agente, data_admissao, situacao_profissional)
+VALUES ('44444444-4444-4444-4444-444444444444','22222222-2222-2222-2222-222222222222','Matemática','Licenciatura','111111111LA045','AG12345','2020-01-10','efetivo');
+
+-- Sample student profile
+INSERT INTO alunos (usuario_id, data_nascimento, genero, nacionalidade)
+VALUES ('33333333-3333-3333-3333-333333333333','2005-05-20','M','Angolana');
+
+-- Sample discipline and class
+INSERT INTO disciplinas (curso_id, professor_id, nome, carga_horaria, periodo, tipo)
+VALUES ((SELECT id FROM cursos WHERE nome = 'Informática' LIMIT 1), '44444444-4444-4444-4444-444444444444', 'Algoritmos', 60, 1, 'obrigatória');
+
+INSERT INTO turmas (curso_id, nome, ano_letivo, turno, sala, periodo_letivo)
+VALUES ((SELECT id FROM cursos WHERE nome = 'Informática' LIMIT 1), '10A', '2024', 'manhã', 'Sala 1', 1);
+
+UPDATE alunos SET turma_id = (SELECT id FROM turmas WHERE nome = '10A' LIMIT 1)
+WHERE usuario_id = '33333333-3333-3333-3333-333333333333';
+
+-- Sample evaluation and grade
+INSERT INTO avaliacoes (id, turma_id, disciplina_id, professor_id, tipo, peso, data_aplicacao)
+VALUES ('55555555-5555-5555-5555-555555555555',(SELECT id FROM turmas WHERE nome='10A'),(SELECT id FROM disciplinas WHERE nome='Algoritmos'),'44444444-4444-4444-4444-444444444444','teste',1,'2024-06-01');
+
+INSERT INTO notas (avaliacao_id, aluno_id, nota, observacao)
+VALUES ('55555555-5555-5555-5555-555555555555','33333333-3333-3333-3333-333333333333',15,'Boa prova');
+
+-- Sample payment, receipt and invoice
+INSERT INTO pagamentos (id, aluno_id, valor, status, metodo_pagamento, vencimento)
+VALUES ('66666666-6666-6666-6666-666666666666','33333333-3333-3333-3333-333333333333',10000,'pendente','multicaixa','2024-07-10');
+
+INSERT INTO agt_faturas (id, pagamento_id, nif, valor, xml_fiscal, status, hash_assinatura)
+VALUES ('77777777-7777-7777-7777-777777777777','66666666-6666-6666-6666-666666666666','500000000',10000,'<xml>demo</xml>','emitida','hash123');
+
+INSERT INTO recibos (id, pagamento_id, url_pdf, data_emissao, gerado_por)
+VALUES ('99999999-9999-9999-9999-999999999999','66666666-6666-6666-6666-666666666666','https://example.com/recibo/demo.pdf',now(),'11111111-1111-1111-1111-111111111111');
+
+-- Sample agenda event and notification
+INSERT INTO agenda_eventos (id, professor_id, turma_id, titulo, tipo, data_inicio, data_fim, descricao)
+VALUES ('88888888-8888-8888-8888-888888888888','44444444-4444-4444-4444-444444444444',(SELECT id FROM turmas WHERE nome='10A'),'Aula de Algoritmos','aula','2024-06-05 08:00','2024-06-05 10:00','Introdução');
+
+INSERT INTO notificacoes (id, usuario_id, titulo, conteudo, tipo)
+VALUES ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','33333333-3333-3333-3333-333333333333','Bem-vindo','Sua matrícula foi registrada','sistema');
+
+-- Sample message between admin and student
+INSERT INTO mensagens (id, remetente_id, destinatario_id, conteudo)
+VALUES ('cccccccc-cccc-cccc-cccc-cccccccccccc','11111111-1111-1111-1111-111111111111','33333333-3333-3333-3333-333333333333','Olá, bem-vindo ao sistema EduManager!');
+
+-- Sample task and response
+INSERT INTO tarefas (id, disciplina_id, turma_id, professor_id, titulo, descricao, data_entrega, peso, tipo)
+VALUES ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',(SELECT id FROM disciplinas WHERE nome='Algoritmos'),(SELECT id FROM turmas WHERE nome='10A'),
+'44444444-4444-4444-4444-444444444444','Trabalho 1','Implementar algoritmo de ordenação','2024-06-15',1,'trabalho');
+
+INSERT INTO respostas_tarefas (tarefa_id, aluno_id, resposta_url)
+VALUES ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','33333333-3333-3333-3333-333333333333','https://example.com/resposta.pdf');

--- a/frontend/boletim.php
+++ b/frontend/boletim.php
@@ -19,18 +19,27 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <head>
 <meta charset="UTF-8" />
 <title>Boletim</title>
+<link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-<h1>Boletim do Aluno</h1>
-<table border="1">
-<tr><th>Disciplina</th><th>Nota</th></tr>
-<?php foreach ($rows as $r): ?>
-<tr>
-    <td><?= htmlspecialchars($r['disciplina']) ?></td>
-    <td><?= htmlspecialchars($r['nota']) ?></td>
-</tr>
-<?php endforeach; ?>
-</table>
-<p><a href="dashboard.php">Voltar ao painel</a></p>
+    <div class="header">
+        <a href="dashboard.php">EduManager</a>
+        <span style="float:right;">
+            <a href="logout.php">Sair</a>
+        </span>
+    </div>
+    <div class="container">
+        <h1>Boletim do Aluno</h1>
+        <table border="1" style="width:100%; border-collapse:collapse;">
+        <tr><th>Disciplina</th><th>Nota</th></tr>
+        <?php foreach ($rows as $r): ?>
+        <tr>
+            <td><?= htmlspecialchars($r['disciplina']) ?></td>
+            <td><?= htmlspecialchars($r['nota']) ?></td>
+        </tr>
+        <?php endforeach; ?>
+        </table>
+        <p><a href="dashboard.php">Voltar ao painel</a></p>
+    </div>
 </body>
 </html>

--- a/frontend/boletim.php
+++ b/frontend/boletim.php
@@ -1,0 +1,36 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['user_tipo'] !== 'aluno') {
+    header('Location: index.php');
+    exit;
+}
+
+$dsn = getenv('DB_DSN') ?: 'pgsql:host=localhost;dbname=edumanager';
+$db_user = getenv('DB_USER') ?: 'postgres';
+$db_pass = getenv('DB_PASS') ?: '';
+
+$pdo = new PDO($dsn, $db_user, $db_pass);
+$stmt = $pdo->prepare('SELECT * FROM gerar_boletim(:aluno)');
+$stmt->execute([':aluno' => $_SESSION['user_id']]);
+$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8" />
+<title>Boletim</title>
+</head>
+<body>
+<h1>Boletim do Aluno</h1>
+<table border="1">
+<tr><th>Disciplina</th><th>Nota</th></tr>
+<?php foreach ($rows as $r): ?>
+<tr>
+    <td><?= htmlspecialchars($r['disciplina']) ?></td>
+    <td><?= htmlspecialchars($r['nota']) ?></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<p><a href="dashboard.php">Voltar ao painel</a></p>
+</body>
+</html>

--- a/frontend/dashboard.php
+++ b/frontend/dashboard.php
@@ -1,0 +1,27 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+    <meta charset="UTF-8" />
+    <title>Painel</title>
+</head>
+<body>
+<h1>Bem-vindo ao EduManager</h1>
+<p>Seu perfil: <?= htmlspecialchars($_SESSION['user_tipo']) ?></p>
+<p>
+    <a href="profile.php">Perfil</a> |
+    <a href="logout.php">Sair</a>
+</p>
+<?php if ($_SESSION['user_tipo'] === 'aluno'): ?>
+<p><a href="boletim.php">Ver Boletim</a></p>
+<p><a href="tarefas.php">Ver Tarefas</a></p>
+<?php endif; ?>
+<p><a href="mensagens.php">Mensagens</a></p>
+</body>
+</html>

--- a/frontend/dashboard.php
+++ b/frontend/dashboard.php
@@ -10,18 +10,24 @@ if (!isset($_SESSION['user_id'])) {
 <head>
     <meta charset="UTF-8" />
     <title>Painel</title>
+    <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-<h1>Bem-vindo ao EduManager</h1>
-<p>Seu perfil: <?= htmlspecialchars($_SESSION['user_tipo']) ?></p>
-<p>
-    <a href="profile.php">Perfil</a> |
-    <a href="logout.php">Sair</a>
-</p>
-<?php if ($_SESSION['user_tipo'] === 'aluno'): ?>
-<p><a href="boletim.php">Ver Boletim</a></p>
-<p><a href="tarefas.php">Ver Tarefas</a></p>
-<?php endif; ?>
-<p><a href="mensagens.php">Mensagens</a></p>
+    <div class="header">
+        <a href="dashboard.php">EduManager</a>
+        <span style="float:right;">
+            <a href="profile.php">Perfil</a>
+            <a href="logout.php">Sair</a>
+        </span>
+    </div>
+    <div class="container">
+        <h1>Bem-vindo</h1>
+        <p>Seu perfil: <?= htmlspecialchars($_SESSION['user_tipo']) ?></p>
+        <?php if ($_SESSION['user_tipo'] === 'aluno'): ?>
+        <p><a href="boletim.php">Ver Boletim</a></p>
+        <p><a href="tarefas.php">Ver Tarefas</a></p>
+        <?php endif; ?>
+        <p><a href="mensagens.php">Mensagens</a></p>
+    </div>
 </body>
 </html>

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -59,14 +59,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8" />
     <title>EduManager Login</title>
+    <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-<h1>EduManager</h1>
-<form method="post">
-    <label>BI: <input type="text" name="bi" required></label><br>
-    <label>Senha: <input type="password" name="senha" required></label><br>
-    <button type="submit">Entrar</button>
-</form>
-<p style="color:red;"><?= htmlspecialchars($message) ?></p>
+    <div class="login-wrapper">
+        <div class="login-box">
+            <h1>EduManager</h1>
+            <form method="post">
+                <input type="text" name="bi" placeholder="Bilhete de Identidade" required>
+                <input type="password" name="senha" placeholder="Senha" required>
+                <button class="btn-primary" type="submit">Entrar</button>
+            </form>
+            <?php if ($message): ?>
+            <p class="message"><?= htmlspecialchars($message) ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
 </body>
 </html>

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -1,0 +1,72 @@
+<?php
+// Simple login form placeholder for XAMPP testing
+// Uses PDO for database connection; adjust .env values accordingly.
+
+session_start();
+
+$dsn = getenv('DB_DSN') ?: 'pgsql:host=localhost;dbname=edumanager';
+$db_user = getenv('DB_USER') ?: 'postgres';
+$db_pass = getenv('DB_PASS') ?: '';
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $bi = $_POST['bi'] ?? '';
+    $senha = $_POST['senha'] ?? '';
+    if ($bi && $senha) {
+        try {
+            $pdo = new PDO($dsn, $db_user, $db_pass);
+            $stmt = $pdo->prepare('SELECT id, senha, nome, tipo FROM usuarios WHERE bi = :bi AND ativo = true');
+            $stmt->execute([':bi' => $bi]);
+            $user = $stmt->fetch(PDO::FETCH_ASSOC);
+            $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+            $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+            if ($user && password_verify($senha, $user['senha'])) {
+                $_SESSION['user_id'] = $user['id'];
+                $_SESSION['user_tipo'] = $user['tipo'];
+                $pdo->prepare('SELECT registrar_login(:uid, true, :ip, :nav, :so, :disp, :ua)')
+                    ->execute([
+                        ':uid' => $user['id'],
+                        ':ip' => $ip,
+                        ':nav' => null,
+                        ':so' => null,
+                        ':disp' => null,
+                        ':ua' => $ua
+                    ]);
+                header('Location: dashboard.php');
+                exit;
+            } else {
+                if ($user) {
+                    $pdo->prepare('SELECT registrar_login(:uid, false, :ip, :nav, :so, :disp, :ua)')
+                        ->execute([
+                            ':uid' => $user['id'],
+                            ':ip' => $ip,
+                            ':nav' => null,
+                            ':so' => null,
+                            ':disp' => null,
+                            ':ua' => $ua
+                        ]);
+                }
+                $message = 'Credenciais inválidas';
+            }
+        } catch (PDOException $e) {
+            $message = 'Erro de conexão: ' . $e->getMessage();
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+    <meta charset="UTF-8" />
+    <title>EduManager Login</title>
+</head>
+<body>
+<h1>EduManager</h1>
+<form method="post">
+    <label>BI: <input type="text" name="bi" required></label><br>
+    <label>Senha: <input type="password" name="senha" required></label><br>
+    <button type="submit">Entrar</button>
+</form>
+<p style="color:red;"><?= htmlspecialchars($message) ?></p>
+</body>
+</html>

--- a/frontend/logout.php
+++ b/frontend/logout.php
@@ -1,0 +1,4 @@
+<?php
+session_start();
+session_destroy();
+header('Location: index.php');

--- a/frontend/mensagens.php
+++ b/frontend/mensagens.php
@@ -41,22 +41,31 @@ try {
 <head>
 <meta charset="UTF-8" />
 <title>Mensagens</title>
+<link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-<h1>Mensagens</h1>
-<p><a href="dashboard.php">Voltar</a></p>
-<?php foreach ($msgs as $m): ?>
-<div style="border:1px solid #ccc;margin:5px;padding:5px;">
-<p><strong><?= htmlspecialchars($m['remetente_id']) ?>:</strong> <?= htmlspecialchars($m['conteudo']) ?></p>
-<p><small><?= htmlspecialchars($m['enviado_em']) ?></small></p>
-</div>
-<?php endforeach; ?>
-<h2>Nova mensagem</h2>
-<form method="post">
-<label>BI Destinatário: <input type="text" name="dest_bi" required></label><br>
-<label>Conteúdo:<br><textarea name="conteudo" required></textarea></label><br>
-<button type="submit">Enviar</button>
-</form>
-<p style="color:green;"><?= htmlspecialchars($message) ?></p>
+    <div class="header">
+        <a href="dashboard.php">EduManager</a>
+        <span style="float:right;">
+            <a href="logout.php">Sair</a>
+        </span>
+    </div>
+    <div class="container">
+        <h1>Mensagens</h1>
+        <p><a href="dashboard.php">Voltar</a></p>
+        <?php foreach ($msgs as $m): ?>
+        <div style="border:1px solid #ccc;margin:5px;padding:5px;">
+            <p><strong><?= htmlspecialchars($m['remetente_id']) ?>:</strong> <?= htmlspecialchars($m['conteudo']) ?></p>
+            <p><small><?= htmlspecialchars($m['enviado_em']) ?></small></p>
+        </div>
+        <?php endforeach; ?>
+        <h2>Nova mensagem</h2>
+        <form method="post">
+            <input type="text" name="dest_bi" placeholder="BI Destinatário" required>
+            <textarea name="conteudo" placeholder="Conteúdo" required></textarea>
+            <button class="btn-primary" type="submit">Enviar</button>
+        </form>
+        <?php if ($message): ?><p class="message" style="color:green;"><?= htmlspecialchars($message) ?></p><?php endif; ?>
+    </div>
 </body>
 </html>

--- a/frontend/mensagens.php
+++ b/frontend/mensagens.php
@@ -1,0 +1,62 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+
+$dsn = getenv('DB_DSN') ?: 'pgsql:host=localhost;dbname=edumanager';
+$db_user = getenv('DB_USER') ?: 'postgres';
+$db_pass = getenv('DB_PASS') ?: '';
+$message = '';
+
+try {
+    $pdo = new PDO($dsn, $db_user, $db_pass);
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $dest_bi = $_POST['dest_bi'] ?? '';
+        $conteudo = $_POST['conteudo'] ?? '';
+        if ($dest_bi && $conteudo) {
+            $stmt = $pdo->prepare('SELECT id FROM usuarios WHERE bi = :bi');
+            $stmt->execute([':bi' => $dest_bi]);
+            $dest = $stmt->fetch(PDO::FETCH_ASSOC);
+            if ($dest) {
+                $pdo->prepare('SELECT enviar_mensagem(:rem,:dest,:cont)')
+                    ->execute([':rem' => $_SESSION['user_id'], ':dest' => $dest['id'], ':cont' => $conteudo]);
+                $message = 'Mensagem enviada';
+            } else {
+                $message = 'Destinatário não encontrado';
+            }
+        }
+    }
+    $stmt = $pdo->prepare('SELECT * FROM listar_mensagens(:uid)');
+    $stmt->execute([':uid' => $_SESSION['user_id']]);
+    $msgs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $message = 'Erro: ' . $e->getMessage();
+    $msgs = [];
+}
+?>
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8" />
+<title>Mensagens</title>
+</head>
+<body>
+<h1>Mensagens</h1>
+<p><a href="dashboard.php">Voltar</a></p>
+<?php foreach ($msgs as $m): ?>
+<div style="border:1px solid #ccc;margin:5px;padding:5px;">
+<p><strong><?= htmlspecialchars($m['remetente_id']) ?>:</strong> <?= htmlspecialchars($m['conteudo']) ?></p>
+<p><small><?= htmlspecialchars($m['enviado_em']) ?></small></p>
+</div>
+<?php endforeach; ?>
+<h2>Nova mensagem</h2>
+<form method="post">
+<label>BI Destinatário: <input type="text" name="dest_bi" required></label><br>
+<label>Conteúdo:<br><textarea name="conteudo" required></textarea></label><br>
+<button type="submit">Enviar</button>
+</form>
+<p style="color:green;"><?= htmlspecialchars($message) ?></p>
+</body>
+</html>

--- a/frontend/profile.php
+++ b/frontend/profile.php
@@ -36,20 +36,33 @@ $user = $stmt->fetch(PDO::FETCH_ASSOC);
 <head>
     <meta charset="UTF-8" />
     <title>Perfil</title>
+    <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-<h1>Perfil do Usuário</h1>
-<p>Nome: <?= htmlspecialchars($user['nome']) ?></p>
-<p>BI: <?= htmlspecialchars($user['bi']) ?></p>
-<p>Tipo: <?= htmlspecialchars($user['tipo']) ?></p>
+    <div class="header">
+        <a href="dashboard.php">EduManager</a>
+        <span style="float:right;">
+            <a href="logout.php">Sair</a>
+        </span>
+    </div>
+    <div class="container">
+        <h1>Perfil do Usuário</h1>
+        <p>Nome: <?= htmlspecialchars($user['nome']) ?></p>
+        <p>BI: <?= htmlspecialchars($user['bi']) ?></p>
+        <p>Tipo: <?= htmlspecialchars($user['tipo']) ?></p>
 
-<h2>Atualizar Senha</h2>
-<form method="post">
-    <label>Senha atual: <input type="password" name="senha_atual" required></label><br>
-    <label>Nova senha: <input type="password" name="nova_senha" required></label><br>
-    <button type="submit">Atualizar</button>
-</form>
-<p style="color:green;"><?= htmlspecialchars($message) ?></p>
-<p><a href="dashboard.php">Voltar ao painel</a></p>
+        <h2>Atualizar Senha</h2>
+        <form method="post">
+            <input type="password" name="senha_atual" placeholder="Senha atual" required>
+            <input type="password" name="nova_senha" placeholder="Nova senha" required>
+            <button class="btn-primary" type="submit">Atualizar</button>
+        </form>
+        <?php if ($message): ?>
+        <p class="message" style="color:green;">
+            <?= htmlspecialchars($message) ?>
+        </p>
+        <?php endif; ?>
+        <p><a href="dashboard.php">Voltar ao painel</a></p>
+    </div>
 </body>
 </html>

--- a/frontend/profile.php
+++ b/frontend/profile.php
@@ -1,0 +1,55 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+
+$dsn = getenv('DB_DSN') ?: 'pgsql:host=localhost;dbname=edumanager';
+$db_user = getenv('DB_USER') ?: 'postgres';
+$db_pass = getenv('DB_PASS') ?: '';
+
+$pdo = new PDO($dsn, $db_user, $db_pass);
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $old = $_POST['senha_atual'] ?? '';
+    $new = $_POST['nova_senha'] ?? '';
+    $biStmt = $pdo->prepare('SELECT bi FROM usuarios WHERE id = :id');
+    $biStmt->execute([':id' => $_SESSION['user_id']]);
+    $bi = $biStmt->fetchColumn();
+    $stmt = $pdo->prepare('SELECT atualizar_senha(:bi, :old, :new)');
+    $stmt->execute([':bi' => $bi, ':old' => $old, ':new' => $new]);
+    if ($stmt->fetchColumn()) {
+        $message = 'Senha atualizada com sucesso';
+    } else {
+        $message = 'Falha ao atualizar senha';
+    }
+}
+
+$stmt = $pdo->prepare('SELECT nome, bi, tipo FROM usuarios WHERE id = :id');
+$stmt->execute([':id' => $_SESSION['user_id']]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+    <meta charset="UTF-8" />
+    <title>Perfil</title>
+</head>
+<body>
+<h1>Perfil do Usuário</h1>
+<p>Nome: <?= htmlspecialchars($user['nome']) ?></p>
+<p>BI: <?= htmlspecialchars($user['bi']) ?></p>
+<p>Tipo: <?= htmlspecialchars($user['tipo']) ?></p>
+
+<h2>Atualizar Senha</h2>
+<form method="post">
+    <label>Senha atual: <input type="password" name="senha_atual" required></label><br>
+    <label>Nova senha: <input type="password" name="nova_senha" required></label><br>
+    <button type="submit">Atualizar</button>
+</form>
+<p style="color:green;"><?= htmlspecialchars($message) ?></p>
+<p><a href="dashboard.php">Voltar ao painel</a></p>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,62 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: #f6f7f9;
+    color: #333;
+}
+.header {
+    background: #17365d;
+    color: #fff;
+    padding: 10px 20px;
+}
+.header a {
+    color: #fff;
+    margin-right: 15px;
+    text-decoration: none;
+}
+.container {
+    max-width: 960px;
+    margin: 40px auto;
+    padding: 0 20px;
+}
+.login-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+}
+.login-box {
+    background: #fff;
+    padding: 40px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    width: 320px;
+}
+.login-box h1 {
+    text-align: center;
+    margin-bottom: 24px;
+    color: #17365d;
+}
+.login-box input {
+    width: 100%;
+    padding: 8px;
+    margin: 8px 0;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+.btn-primary {
+    background: #17365d;
+    color: white;
+    border: none;
+    padding: 10px;
+    width: 100%;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.btn-primary:hover {
+    background: #145;
+}
+.message {
+    color: red;
+    text-align: center;
+}

--- a/frontend/tarefas.php
+++ b/frontend/tarefas.php
@@ -1,0 +1,73 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['user_tipo'] !== 'aluno') {
+    header('Location: index.php');
+    exit;
+}
+
+$dsn = getenv('DB_DSN') ?: 'pgsql:host=localhost;dbname=edumanager';
+$db_user = getenv('DB_USER') ?: 'postgres';
+$db_pass = getenv('DB_PASS') ?: '';
+$pdo = new PDO($dsn, $db_user, $db_pass);
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $tarefa = $_POST['tarefa_id'] ?? '';
+    $url = $_POST['resposta_url'] ?? '';
+    if ($tarefa && $url) {
+        $stmt = $pdo->prepare('SELECT responder_tarefa(:tarefa, :aluno, :url)');
+        $stmt->execute([
+            ':tarefa' => $tarefa,
+            ':aluno' => $_SESSION['user_id'],
+            ':url' => $url
+        ]);
+        $message = 'Resposta enviada.';
+    }
+}
+
+$turmaStmt = $pdo->prepare('SELECT turma_id FROM alunos WHERE usuario_id = :uid');
+$turmaStmt->execute([':uid' => $_SESSION['user_id']]);
+$turma_id = $turmaStmt->fetchColumn();
+
+$tarefasStmt = $pdo->prepare('SELECT t.id, t.titulo, t.descricao, t.data_entrega, rt.resposta_url
+                              FROM tarefas t
+                              LEFT JOIN respostas_tarefas rt
+                                ON rt.tarefa_id = t.id AND rt.aluno_id = :aluno
+                              WHERE t.turma_id = :turma
+                              ORDER BY t.data_entrega');
+$tarefasStmt->execute([':turma' => $turma_id, ':aluno' => $_SESSION['user_id']]);
+$tarefas = $tarefasStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8" />
+<title>Tarefas</title>
+</head>
+<body>
+<h1>Tarefas da Turma</h1>
+<?php if ($message): ?><p style="color:green;"><?= htmlspecialchars($message) ?></p><?php endif; ?>
+<table border="1">
+<tr><th>Título</th><th>Descrição</th><th>Entrega</th><th>Resposta</th></tr>
+<?php foreach ($tarefas as $t): ?>
+<tr>
+    <td><?= htmlspecialchars($t['titulo']) ?></td>
+    <td><?= htmlspecialchars($t['descricao']) ?></td>
+    <td><?= htmlspecialchars($t['data_entrega']) ?></td>
+    <td>
+        <?php if ($t['resposta_url']): ?>
+            <a href="<?= htmlspecialchars($t['resposta_url']) ?>" target="_blank">Ver Resposta</a>
+        <?php else: ?>
+            <form method="post" style="display:inline">
+                <input type="hidden" name="tarefa_id" value="<?= htmlspecialchars($t['id']) ?>">
+                <input type="text" name="resposta_url" placeholder="URL da resposta" required>
+                <button type="submit">Enviar</button>
+            </form>
+        <?php endif; ?>
+    </td>
+</tr>
+<?php endforeach; ?>
+</table>
+<p><a href="dashboard.php">Voltar ao painel</a></p>
+</body>
+</html>

--- a/frontend/tarefas.php
+++ b/frontend/tarefas.php
@@ -43,31 +43,40 @@ $tarefas = $tarefasStmt->fetchAll(PDO::FETCH_ASSOC);
 <head>
 <meta charset="UTF-8" />
 <title>Tarefas</title>
+<link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-<h1>Tarefas da Turma</h1>
-<?php if ($message): ?><p style="color:green;"><?= htmlspecialchars($message) ?></p><?php endif; ?>
-<table border="1">
-<tr><th>Título</th><th>Descrição</th><th>Entrega</th><th>Resposta</th></tr>
-<?php foreach ($tarefas as $t): ?>
-<tr>
-    <td><?= htmlspecialchars($t['titulo']) ?></td>
-    <td><?= htmlspecialchars($t['descricao']) ?></td>
-    <td><?= htmlspecialchars($t['data_entrega']) ?></td>
-    <td>
-        <?php if ($t['resposta_url']): ?>
-            <a href="<?= htmlspecialchars($t['resposta_url']) ?>" target="_blank">Ver Resposta</a>
-        <?php else: ?>
-            <form method="post" style="display:inline">
-                <input type="hidden" name="tarefa_id" value="<?= htmlspecialchars($t['id']) ?>">
-                <input type="text" name="resposta_url" placeholder="URL da resposta" required>
-                <button type="submit">Enviar</button>
-            </form>
-        <?php endif; ?>
-    </td>
-</tr>
-<?php endforeach; ?>
-</table>
-<p><a href="dashboard.php">Voltar ao painel</a></p>
+    <div class="header">
+        <a href="dashboard.php">EduManager</a>
+        <span style="float:right;">
+            <a href="logout.php">Sair</a>
+        </span>
+    </div>
+    <div class="container">
+        <h1>Tarefas da Turma</h1>
+        <?php if ($message): ?><p class="message" style="color:green;"><?= htmlspecialchars($message) ?></p><?php endif; ?>
+        <table border="1" style="width:100%; border-collapse:collapse;">
+        <tr><th>Título</th><th>Descrição</th><th>Entrega</th><th>Resposta</th></tr>
+        <?php foreach ($tarefas as $t): ?>
+        <tr>
+            <td><?= htmlspecialchars($t['titulo']) ?></td>
+            <td><?= htmlspecialchars($t['descricao']) ?></td>
+            <td><?= htmlspecialchars($t['data_entrega']) ?></td>
+            <td>
+                <?php if ($t['resposta_url']): ?>
+                    <a href="<?= htmlspecialchars($t['resposta_url']) ?>" target="_blank">Ver Resposta</a>
+                <?php else: ?>
+                    <form method="post" style="display:inline">
+                        <input type="hidden" name="tarefa_id" value="<?= htmlspecialchars($t['id']) ?>">
+                        <input type="text" name="resposta_url" placeholder="URL da resposta" required>
+                        <button class="btn-primary" type="submit">Enviar</button>
+                    </form>
+                <?php endif; ?>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+        </table>
+        <p><a href="dashboard.php">Voltar ao painel</a></p>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand SQL schema with evaluation, payment, agenda and notification tables plus RPC helpers for reports, receipts and AGT invoices
- seed sample discipline, class, evaluation, payment and notification data
- add student report card page and link from dashboard
- introduce homework tables and RPCs with a demo task
- add student tasks page linked from the dashboard
- add basic messaging table, RPCs and PHP page for user messages

## Testing
- `php -l frontend/index.php`
- `php -l frontend/dashboard.php`
- `php -l frontend/logout.php`
- `php -l frontend/profile.php`
- `php -l frontend/boletim.php`
- `php -l frontend/tarefas.php`
- `php -l frontend/mensagens.php`


------
https://chatgpt.com/codex/tasks/task_e_688ee758247083329e1aba5a443f347a